### PR TITLE
add violent score dimension to Hive implementation

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 AIRTABLE_KEY=test-at-key-123
 AIRTABLE_BASE_ID=test-at-base
+HIVE_AI_KEY=test-api-key
 MUX_TOKEN_ID=test-mux-id
 MUX_TOKEN_SECRET=test-mux-secret
 NEXT_PUBLIC_MUX_ENV_KEY=test-mux-env-key

--- a/lib/moderation-action.spec.ts
+++ b/lib/moderation-action.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+import { autoDelete } from './moderation-action';
+import nock from 'nock';
+
+beforeEach(() => {
+  nock.disableNetConnect();
+});
+
+test('deletes the mux playback ID if adult >= 0.95', async () => {
+  const hiveScores = { adult: 0.99, suggestive: 0.11, violent: 0.234 };
+  const assetId = 'asset-123';
+  const playbackId = 'playback-123';
+  const scopeMux = nock('https://api.mux.com/video/v1/').delete(`/assets/${assetId}/playback-ids/${playbackId}`).reply(204);
+  const scopeAirtable = nock('https://api.airtable.com/v0').post(`/${process.env.AIRTABLE_BASE_ID}/Auto%20Deleted`).reply(200);
+
+  const isDeleted = await autoDelete({ assetId, playbackId, hiveScores });
+
+  expect(isDeleted).toEqual(true);
+  expect(scopeMux.isDone()).toEqual(true);
+  expect(scopeAirtable.isDone()).toEqual(true);
+});
+
+test('returns false if no autoDelete happened', async () => {
+  const hiveScores = { adult: 0.89, suggestive: 0.11, violent: 0.234 };
+  const assetId = 'asset-123';
+  const playbackId = 'playback-123';
+  const isDeleted = await autoDelete({ assetId, playbackId, hiveScores });
+
+  expect(isDeleted).toEqual(false);
+});

--- a/lib/moderation-action.ts
+++ b/lib/moderation-action.ts
@@ -1,0 +1,35 @@
+import { ModerationScores } from '../types';
+import Mux from '@mux/mux-node';
+import got from 'got';
+
+const { Video } = new Mux();
+
+async function saveDeletionRecordInAirtable ({ assetId, notes }: { assetId: string, notes: string }) {
+  if (process.env.AIRTABLE_KEY && process.env.AIRTABLE_BASE_ID) {
+    try {
+      await got.post(`https://api.airtable.com/v0/${process.env.AIRTABLE_BASE_ID}/Auto Deleted`, {
+        headers: {
+          Authorization: `Bearer ${process.env.AIRTABLE_KEY}`
+        },
+        json: {
+          records: [
+            {fields: { assetId, notes } },
+          ]
+        }
+      });
+    } catch (e) {
+      console.error('Error reporting to airtable', e.response && e.response.body, e); // eslint-disable-line no-console
+    }
+  }
+}
+
+export async function autoDelete({ assetId, playbackId, hiveScores }: { assetId: string, playbackId: string, hiveScores: ModerationScores }): Promise<boolean> {
+  if (hiveScores && hiveScores.adult && hiveScores.adult >= 0.95) {
+    await Video.Assets.deletePlaybackId(assetId, playbackId);
+    await saveDeletionRecordInAirtable({ assetId, notes: JSON.stringify(hiveScores) });
+
+    return true;
+  }
+
+  return false;
+}

--- a/lib/moderation-google.ts
+++ b/lib/moderation-google.ts
@@ -51,7 +51,7 @@ async function fetchAnnotationsForUrl (url: string): Promise<SafeSearchAnnotatio
   }
 
   if (result.error) {
-    console.error('Error detecting scores', url);
+    console.error('Error detecting scores for google', url);
     return null;
   }
   const detections = result.safeSearchAnnotation;

--- a/lib/moderation-hive.spec.ts
+++ b/lib/moderation-hive.spec.ts
@@ -1,8 +1,11 @@
+/**
+ * @jest-environment node
+ */
+
 import { getScores } from './moderation-hive';
 import nock from 'nock';
 
 beforeEach(() => {
-  process.env.HIVE_AI_KEY = process.env.HIVE_AI_KEY || 'test-api-key';
   nock.disableNetConnect();
 });
 

--- a/lib/moderation-hive.spec.ts
+++ b/lib/moderation-hive.spec.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
   nock.disableNetConnect();
 });
 
-function nockNsfwScore ({ adult, suggestive } : { adult: number, suggestive: number }) {
+function nockNsfwScore ({ adult, suggestive, veryBloody } : { adult: number, suggestive: number, veryBloody: number }) {
   return nock('https://api.thehive.ai/api/v2').post('/task/sync').reply(200, {
     code: 200,
     status: [
@@ -24,6 +24,10 @@ function nockNsfwScore ({ adult, suggestive } : { adult: number, suggestive: num
                   class: "general_suggestive",
                   score: suggestive
                 },
+                {
+                  class: "very_bloody",
+                  score: veryBloody
+                },
               ]
             }
           ]
@@ -34,13 +38,14 @@ function nockNsfwScore ({ adult, suggestive } : { adult: number, suggestive: num
 }
 
 test('gets a combined score for 3 files', async () => {
-  const scopeUrl1 = nockNsfwScore({ adult: 0.9925124, suggestive: 0.1123 });
-  const scopeUrl2 = nockNsfwScore({ adult: 0.881235, suggestive: 0.79251 });
-  const scopeUrl3 = nockNsfwScore({ adult: 0.0389421, suggestive: 0.00482 });
+  const scopeUrl1 = nockNsfwScore({ adult: 0.9925124, suggestive: 0.1123, veryBloody: 0.123 });
+  const scopeUrl2 = nockNsfwScore({ adult: 0.881235, suggestive: 0.79251, veryBloody: 0.134 });
+  const scopeUrl3 = nockNsfwScore({ adult: 0.0389421, suggestive: 0.00482, veryBloody: 0.456 });
   const scores = await getScores({ playbackId: '123', duration: 30 });
 
   expect(scores?.adult).toEqual(0.992512);
   expect(scores?.suggestive).toEqual(0.79251);
+  expect(scores?.violent).toEqual(0.456);
   expect(scopeUrl1.isDone()).toEqual(true);
   expect(scopeUrl2.isDone()).toEqual(true);
   expect(scopeUrl3.isDone()).toEqual(true);

--- a/lib/moderation-hive.ts
+++ b/lib/moderation-hive.ts
@@ -44,7 +44,7 @@ async function fetchOutputForUrl (url: string): Promise<HiveOutput|null> {
   }
 
   if (result.code !== 200) {
-    console.error('Error detecting scores', result.code, url);
+    console.error('Error detecting scores for hive', result.code, url);
     return null;
   }
 

--- a/lib/moderation-hive.ts
+++ b/lib/moderation-hive.ts
@@ -63,20 +63,29 @@ function roundedScore (score: number) {
 export function mergeAnnotations (outputs: HiveOutput[]): ModerationScores {
   const adultScores: number[] = [];
   const suggestiveScores: number[] = [];
+  const violentScores: number[] = [];
 
   outputs.forEach((output) => {
     const nsfwScore = (output.classes.find((cls => cls.class === "general_nsfw")) as HiveClass).score;
-    adultScores.push(roundedScore(nsfwScore));
-  });
+    if (nsfwScore) {
+      adultScores.push(roundedScore(nsfwScore));
+    }
 
-  outputs.forEach((output) => {
     const suggestiveScore = (output.classes.find((cls => cls.class === "general_suggestive")) as HiveClass).score;
-    suggestiveScores.push(roundedScore(suggestiveScore));
+    if (suggestiveScore) {
+      suggestiveScores.push(roundedScore(suggestiveScore));
+    }
+
+    const bloodyScore = (output.classes.find((cls => cls.class === "very_bloody")) as HiveClass).score;
+    if (bloodyScore) {
+      violentScores.push(roundedScore(bloodyScore));
+    }
   });
 
   const combined: ModerationScores = {
     adult: adultScores.length ? Math.max(...adultScores) : undefined,
     suggestive: suggestiveScores.length ? Math.max(...suggestiveScores) : undefined,
+    violent: violentScores.length ? Math.max(...violentScores) : undefined,
   };
 
   return combined;

--- a/lib/slack-notifier.ts
+++ b/lib/slack-notifier.ts
@@ -151,6 +151,22 @@ export const sendSlackAssetReady = async ({ playbackId, assetId, duration, googl
   return null;
 };
 
+export const sendSlackAutoDeleteMessage = async ({ assetId, duration, hiveScores }: { assetId: string, duration: number, hiveScores?: ModerationScores }): Promise<null> => {
+  if (!slackWebhook) {
+    console.log('No slack webhook configured'); // eslint-disable-line no-console
+    return null;
+  }
+
+  await got.post(slackWebhook, {
+    json: {
+      text: `Auto-deleted by moderator: ${assetId} duration: ${duration}. ${JSON.stringify(hiveScores)}`,
+      icon_emoji: 'female-police-officer',
+    },
+  });
+
+  return null;
+};
+
 export const sendAbuseReport = async ({ playbackId, reason, comment }: {playbackId: string, reason: string, comment?: string}): Promise<null> => {
   if (!slackWebhook) {
     console.log('No slack webhook configured'); // eslint-disable-line no-console

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/vision": "^2.3.2",
-    "@mux/mux-node": "^3.0",
+    "@mux/mux-node": "^3.2",
     "@mux/upchunk": "^2.2",
     "copy-to-clipboard": "^3.3.1",
     "got": "^11.5.1",

--- a/pages/api/report.ts
+++ b/pages/api/report.ts
@@ -16,7 +16,7 @@ const notify = async ({playbackId, reason, comment }: { playbackId: string, reas
         }
       });
     } catch (e) {
-      console.error('Error reporting to airtable', e); // eslint-disable-line no-console
+      console.error('Error reporting to airtable', e.response.body); // eslint-disable-line no-console
     }
   }
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,10 +588,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mux/mux-node@^3.0":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@mux/mux-node/-/mux-node-3.1.4.tgz#0360076bbb7b33ab7f5476951f356430d2e19b64"
-  integrity sha512-VCpckpYa+bgYDU+YjGE9YjySJl2zCmxgY4IjsHSKYnyInKRrcFA0VIQ6RKMyarJzCxvy4sjC64uBhhlqDLIpMw==
+"@mux/mux-node@^3.2":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@mux/mux-node/-/mux-node-3.2.3.tgz#2ca6b54d6d48972a6fce9b301674a876430a3c54"
+  integrity sha512-incFthoAPP2RJrptWnSF0/1OX5ws0X1hnkUscA7PP57Ka1y6597/vhxpbdKb4K7GkKBJ0DEyDpfFBMdC0II1sA==
   dependencies:
     axios "^0.21.1"
     esdoc-ecmascript-proposal-plugin "^1.0.0"


### PR DESCRIPTION
Below is the full list of classifications that Hive does. Some of these classifications are the top level ["head" models](https://docs.thehive.ai/reference#classification) -- like `general_nsfw` and `general_suggestive`. And then those head models have subclassifications (`yes_female_nudity` and `yes_male_nudity` are models that belong to the single model head).

As of now there is no `general_violence` head model, so we have to go off one of the other subclassifications. I went with `very_bloody`, but something else like `other_blood`, `a_little_bloody`, `knife_in_hand`, `gun_in_hand` might be good too (or we come up with some kind of strategy that does some kind combination or simply takes the max of these classifications that indicate violence.

```
- animated
- text
- yes_overlay_text
- natural
- hybrid
- general_nsfw
- general_suggestive
- yes_female_underwear
- yes_male_underwear
- yes_sex_toy
- yes_female_nudity
- yes_male_nudity
- yes_female_swimwear
- yes_male_shirtless
- animated_gun
- gun_in_hand
- gun_not_in_hand
- culinary_knife_in_hand
- knife_in_hand
- knife_not_in_hand
- a_little_bloody
- other_blood
- very_bloody
- yes_pills
- yes_smoking
- illicit_injectables
- medical_injectables
- yes_nazi
- yes_kkk
- yes_middle_finger
- yes_terrorist
- yes_sexual_activity
- hanging
- noose
```