### PR TITLE
bugfix/safari layout aspect ratio

### DIFF
--- a/components/player-loader.tsx
+++ b/components/player-loader.tsx
@@ -26,11 +26,9 @@ const PlayerLoader = forwardRef<HTMLVideoElementWithPlyr, Props>(({ playbackId, 
           margin-bottom: 40px;
           margin-top: 40px;
           border-radius: 30px;
-          height: 0px;
-          aspect-ratio: ${aspectRatio};
+          height: 0;
           flex-shrink: 1;
           flex-grow: 1;
-          object-fit: contain;
         }
       `}
       </style>


### PR DESCRIPTION
- aspect-ratio and object-fit were not behaving in Safari

This is a bit of a temp fix, because the layout still jumps a bit
on pageload is which not what we want :( -- but still, this is
better until we have a more permantent fix

# Current

![current_2022-02-22_18-23-10](https://user-images.githubusercontent.com/764988/155251933-6a56dce5-5655-4cab-a644-8893786b4484.png)



# Fixed

![fixed_2022-02-22_18-22-56](https://user-images.githubusercontent.com/764988/155251958-71166f74-0280-4ba5-b6c4-8b786d19587e.png)

